### PR TITLE
Swap black pre-commit repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,8 @@ repos:
      hooks:
        - id: flake8
   
-  -  repo: https://github.com/ambv/black
-     rev: 23.7.0
+  -  repo: https://github.com/psf/black-pre-commit-mirror
+     rev: 23.9.1
      hooks: 
      - id: black
        language_version: python3.11

--- a/Pipfile
+++ b/Pipfile
@@ -19,7 +19,7 @@ qdrant-client = "==1.5.4"
 [dev-packages]
 pytest = "==7.4.2"
 isort = "==5.12.0"
-black = "==23.7.0"
+black = "==23.9.1"
 flake8 = "==6.1.0"
 pre-commit = "==3.3.3"
 


### PR DESCRIPTION
This PR swaps the black pre-commit repo from https://github.com/ambv/black to https://github.com/psf/black-pre-commit-mirror.