### PR TITLE
Remove `linkTarget` which is an option removed in react-markdown 9.0.0

### DIFF
--- a/chatbot-ui/pages/index.tsx
+++ b/chatbot-ui/pages/index.tsx
@@ -193,9 +193,7 @@ function Home() {
                     >
                       {icon}
                       <div className={styles.markdownanswer}>
-                        <ReactMarkdown linkTarget="_blank">
-                          {message.message}
-                        </ReactMarkdown>
+                        <ReactMarkdown>{message.message}</ReactMarkdown>
                       </div>
                     </div>
                   </>


### PR DESCRIPTION
Remove `linkTarget` from `ReactMarkdown` as it's an option removed in `react-markdown:9.0.0`. This is to allow for the major dependency upgrade.