### PR TITLE
chore: Fix Next.js build by moving jest tests outside pages folder

### DIFF
--- a/chatbot-ui/__tests__/index.test.tsx
+++ b/chatbot-ui/__tests__/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import Home from './index';
+import Home from '../pages/index';
 
 describe('Home Page', () => {
   it('Renders', () => {

--- a/chatbot-ui/jest.config.mjs
+++ b/chatbot-ui/jest.config.mjs
@@ -1,5 +1,7 @@
 import nextJest from 'next/jest.js';
 
+process.env.NODE_ENV = 'test';
+
 const createJestConfig = nextJest({
   dir: './',
 });


### PR DESCRIPTION
Fixes the error

```
13.07 ReferenceError: describe is not defined
13.07     at /app/chatbot-ui/.next/server/pages/index.test.js:1:1212
```

when running `next build` by moving Jest test files outside the `pages` folder.