### PR TITLE
EES-4765 Containerise frontend app with Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,7 @@
 **/.env
 **/.git
 **/.gitignore
+**/.md
 **/Dockerfile
+**/node_modules
+**/.next

--- a/chatbot-ui/Dockerfile
+++ b/chatbot-ui/Dockerfile
@@ -1,0 +1,48 @@
+FROM node:20.10.0-alpine AS base
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+FROM base AS deps
+WORKDIR /app
+
+COPY .npmrc package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY chatbot-ui/package.json chatbot-ui/package-lock.json ./chatbot-ui/
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm --filter chatbot-ui install --frozen-lockfile
+
+FROM base AS builder
+WORKDIR /app
+
+COPY .npmrc package.json pnpm-lock.yaml pnpm-workspace.yaml .prettierrc .prettierignore ./
+COPY chatbot-ui ./chatbot-ui/
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/chatbot-ui/node_modules ./chatbot-ui/node_modules
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm --filter chatbot-ui run build
+
+FROM base AS runner
+WORKDIR /app
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/chatbot-ui/public ./chatbot-ui/public
+
+# Set the correct permission for prerender cache
+#RUN mkdir .next
+#RUN chown nextjs:nodejs .next
+
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/chatbot-ui/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/chatbot-ui/.next/static ./chatbot-ui/.next/static
+
+USER nextjs
+
+ENV NODE_ENV=production
+ENV PORT=3000
+EXPOSE 3000
+
+# server.js is created by next build from the standalone output
+# https://nextjs.org/docs/pages/api-reference/next-config-js/output
+CMD ["node", "chatbot-ui/server.js"]

--- a/chatbot-ui/next.config.js
+++ b/chatbot-ui/next.config.js
@@ -1,6 +1,16 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
 /** @type {import('next').NextConfig} */
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 const nextConfig = {
+  output: 'standalone',
+  experimental: {
+    // this includes files from the monorepo base one directory up
+    outputFileTracingRoot: path.join(__dirname, '../'),
+  },
   poweredByHeader: false,
   reactStrictMode: true,
   swcMinify: true,


### PR DESCRIPTION
This PR adds a Dockerfile to allow running the frontend app in a container.

It's based on the Next.js example [With Docker](https://github.com/vercel/next.js/tree/canary/examples/with-docker).

It introduces one bug on Windows when starting without Docker. The error `Error: EPERM: operation not permitted, scandir` occurs during the build after adding `output: 'standalone'` to `next.config.js`.

This appears to be https://github.com/vercel/next.js/issues/40760 and a temp workaround is to remove the `.next` directory before start-up.