### PR TITLE
EES-4765 Change `CHAT_URL_PUBLIC_UI` to `API_ALLOW_ORIGINS`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,4 @@
-CHAT_URL_API=http://localhost:8010/api/chat
-CHAT_URL_PUBLIC_UI=http://localhost:3002
+API_ALLOW_ORIGINS='["http://localhost:3002"]'
 EES_URL_API_CONTENT=http://localhost:5010/api
 EES_URL_API_DATA=http://localhost:5000/api
 EES_URL_PUBLIC_UI=http://localhost:3000

--- a/response_automater/config.py
+++ b/response_automater/config.py
@@ -4,7 +4,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
-    chat_url_public_ui: str = "http://localhost:3002"
+    api_allow_origins: list[str] = ["http://localhost:3002"]
     openai_api_key: str = "placeholder-value"
     openai_model: str = "gpt-4"
     openai_embedding_model: str = "text-embedding-ada-002"

--- a/response_automater/main.py
+++ b/response_automater/main.py
@@ -12,11 +12,9 @@ dictConfig(LOGGING_CONFIG)
 
 app = FastAPI()
 
-origins = [settings.chat_url_public_ui]
-
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,
+    allow_origins=settings.api_allow_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
This PR makes changes to the response automater chat API's environment:

- Rename CORS allow origins variable from `CHAT_URL_PUBLIC_UI` to `API_ALLOW_ORIGINS` which now also accepts an array of values.
- Remove `CHAT_URL_API` variable which is unused.