### PR TITLE
Rename to Support bot and other text amendments

### DIFF
--- a/chatbot-prototype.code-workspace
+++ b/chatbot-prototype.code-workspace
@@ -26,7 +26,7 @@
     }
   ],
   "settings": {
-    "window.title": "Chatbot Prototype",
+    "window.title": "Support bot",
     "[python]": {
       "editor.defaultFormatter": "ms-python.black-formatter"
     },

--- a/chatbot-ui/__tests__/index.test.tsx
+++ b/chatbot-ui/__tests__/index.test.tsx
@@ -6,6 +6,6 @@ describe('Home Page', () => {
   it('Renders', () => {
     render(<Home />);
 
-    expect(screen.getByText('Chatbot prototype')).toBeInTheDocument();
+    expect(screen.getByText('Support bot')).toBeInTheDocument();
   });
 });

--- a/chatbot-ui/components/UserInputDialog.tsx
+++ b/chatbot-ui/components/UserInputDialog.tsx
@@ -53,7 +53,7 @@ const UserInputDialog = ({ sendMessage, error: APIError, fetching }: Props) => {
           </label>
         </h1>
         <div id="question-hint" className="govuk-hint">
-          Ask whatever question you like...
+          Ask a question relevant to the Explore Education Statistics service...
         </div>
 
         {userInputError && <ErrorSummary error={userInputError} />}

--- a/chatbot-ui/hooks/useChatbot.test.ts
+++ b/chatbot-ui/hooks/useChatbot.test.ts
@@ -12,7 +12,7 @@ describe('useChatbot', () => {
     const { messages } = result.current;
     expect(messages).toHaveLength(1);
     expect(messages[0].content).toBe(
-      'Hi, what would you like to know about the latest publications on EES?',
+      'Hi, what would you like to know about Explore Education Statistics?',
     );
   });
 
@@ -25,7 +25,7 @@ describe('useChatbot', () => {
     const { messages } = result.current;
     expect(messages).toHaveLength(1);
     expect(messages[0].content).toBe(
-      'Hi, what would you like to know about the latest publications on EES?',
+      'Hi, what would you like to know about Explore Education Statistics?',
     );
 
     await act(() => result.current.sendMessage('I am a message'));

--- a/chatbot-ui/hooks/useChatbot.ts
+++ b/chatbot-ui/hooks/useChatbot.ts
@@ -7,7 +7,7 @@ function useChatbot(): UseChatbotState {
   const [messageHistory, setMessageHistory] = useState<Message[]>([
     {
       content:
-        'Hi, what would you like to know about the latest publications on EES?',
+        'Hi, what would you like to know about Explore Education Statistics?',
       type: 'apiMessage',
     },
   ]);

--- a/chatbot-ui/pages/index.tsx
+++ b/chatbot-ui/pages/index.tsx
@@ -9,7 +9,7 @@ function Home() {
   const { messages, sendMessage, fetching, error } = useChatbot();
 
   return (
-    <Page title="Chatbot prototype">
+    <Page title="Support bot">
       <>
         {error && <ErrorSummary error={error} />}
 

--- a/infrastructure/azure-pipelines-ci.yaml
+++ b/infrastructure/azure-pipelines-ci.yaml
@@ -1,4 +1,4 @@
-name: 'Chatbot Prototype CI Pipeline'
+name: 'Support bot CI pipeline'
 
 trigger:
   - main

--- a/infrastructure/azure-pipelines-pr.yaml
+++ b/infrastructure/azure-pipelines-pr.yaml
@@ -1,4 +1,4 @@
-name: 'Chatbot Prototype Pull Request Pipeline'
+name: 'Support bot PR pipeline'
 
 trigger: none
 pr:


### PR DESCRIPTION
This PR alters references to 'Chatbot Prototype' to become 'Support bot'. It also makes some other small text amendments in the content.