### PR TITLE
EES-4789 Set web auth password environment variable from key vault

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -182,6 +182,7 @@ module web './app/web.bicep' = {
     applicationInsightsName: monitoring.outputs.applicationInsightsName
     containerAppsEnvironmentName: containerAppsEnv.outputs.name
     containerRegistryName: containerRegistry.outputs.name
+    keyVaultName: keyVault.outputs.name
     exists: webAppExists
     appDefinition: webAppDefinition
     apiBaseUrl: api.outputs.uri

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -60,7 +60,7 @@
     },
     "webAppDefinition": {
       "value": {
-        "settings": [{ "name": "AUTH_PASSWORD", "value": "${AUTH_PASSWORD}" }]
+        "settings": []
       }
     }
   }


### PR DESCRIPTION
This PR changes the web frontend auth password from being a template param set in DevOps to be a secret stored in key vault.

This change depends on a key vault secret already existing with the name `web-auth-password`.

It sets up the `AUTH_PASSWORD` environment variable in the web container which references the `auth-password` container secret, which is itself a reference to the `web-auth-password` key vault secret using the secret URI.

If the secret value is changed the app should automatically retrieve the latest version within 30 minutes . The container should be automatically restarted to pick up the new value.

Note: I wasn't able to get this working if the key vault secret is defined as a resource in the bicep template which would have been preferable to make sure it exists on first provision. Provisioning would fail from scratch until the key vault secret is created manually. However defining the secret as a resource and reprovisioning was also reverting any value that I was manually setting in newer versions of it back to the default value specified in the template, so that would have been another issue to resolve as well.