### PR TITLE
On page load/refresh, set focus to password input

### DIFF
--- a/chatbot-ui/components/UserCredentialEntry.tsx
+++ b/chatbot-ui/components/UserCredentialEntry.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import { useEffect, useRef } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
 interface AuthData {
@@ -20,6 +21,12 @@ const UserCredentialEntry = ({ onCorrectEntry, authPassword }: Props) => {
       setError('password', { message: 'Incorrect password', type: 'wrong' });
     }
   };
+
+  const passwordInput = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    passwordInput?.current?.focus();
+  });
 
   return (
     <form id="user-input-form" onSubmit={handleSubmit(onSubmit)}>
@@ -52,6 +59,7 @@ const UserCredentialEntry = ({ onCorrectEntry, authPassword }: Props) => {
             {...register('password', {
               required: true,
             })}
+            ref={passwordInput}
             className="govuk-input"
             id="auth-password"
             name="password"


### PR DESCRIPTION
Minor quality-of-life improvement: give the password field the focus on page load/refresh.

This means you can click the link and just start typing rather than having to tab/use a mouse first.

Will update to be username field instead if we end up adding that